### PR TITLE
fix: call onConnected when connected

### DIFF
--- a/frontend/src/graphql-client/create-client.ts
+++ b/frontend/src/graphql-client/create-client.ts
@@ -33,7 +33,7 @@ export function createApolloSubscriptionClient({
         disconnected = true;
       },
       connected: (socket) => {
-        if (!disconnected && onConnected) {
+        if (onConnected) {
           onConnected(socket);
         }
 


### PR DESCRIPTION
You were invoking `onConnected` only once. `if (!disconnected && onConnected)` translates to "if first time connecting". This is why you had a stale socket, nothing to do with `graphql-ws`.

The reason why it worked with the `opened` event is because you called actually called `onConnected` on each connect. Notice your comment on https://github.com/enisdenjo/graphql-ws/discussions/320#discussioncomment-2262484:
> Then in my actual code, I've solved the problem via:
>
> ```diff
> on: {
>      closed: () => {
>        disconnected = true;
>      },
>      opened: (socket) => {
>+       // 👇 no !disconnected check
>        if (onConnected) {
>          // Refresh the socket reference so subsequent refreshes
>          // will work properly
>          onConnected(socket);
>        }
>      },
>   ...
>}
>```